### PR TITLE
Fixing Grails config access for preserve tag name case

### DIFF
--- a/TaggableGrailsPlugin.groovy
+++ b/TaggableGrailsPlugin.groovy
@@ -21,7 +21,7 @@ import grails.util.*
  * @author Graeme Rocher
  */
 class TaggableGrailsPlugin {
-    def version = "1.1.0-PG-3"
+    def version = "1.1.0-PG-4"
     def grailsVersion = "2.5 > *"
     def license = 'APACHE'
 

--- a/grails-app/domain/org/grails/taggable/Tag.groovy
+++ b/grails-app/domain/org/grails/taggable/Tag.groovy
@@ -27,7 +27,8 @@ class Tag implements Serializable{
 
     static Boolean preserveCaseForTesting = null
     static boolean getPreserveCaseFromConfig() {
-        Holders.config.getProperty('grails.taggable.preserve.case', Boolean, false)
+        Holders.config?.grails?.taggable?.preserve?.case instanceof ConfigObject ? false :
+                Holders.config.grails.taggable.preserve.case.toString().toBoolean()
     }
     static boolean getPreserveCase() {
         return (preserveCaseForTesting != null) ? preserveCaseForTesting : preserveCaseFromConfig


### PR DESCRIPTION
`getProperty(java.lang.String key, java.lang.Class<T> targetType, T defaultValue, java.util.List<T> allowedValues)` wasn't added until Grails 3 unfortunately, I'm not sure why this didn't show up locally because that method was being invoked. This is causing issues on circleci though.